### PR TITLE
Check filename case and permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy Vite site to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [ Main ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Update GitHub Actions workflow to deploy from `Main` branch.

This resolves a GitHub Pages deployment issue caused by case sensitivity between `main` and `Main` branches, ensuring the workflow uses the intended `Main` branch for deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6218aa6-c604-4683-bc7e-a9a608809203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c6218aa6-c604-4683-bc7e-a9a608809203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

